### PR TITLE
setup dev environment with flake

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -4,5 +4,5 @@ pkgs.buildGoModule {
   pname = "go-nix";
   version = "latest";
   src = pkgs.lib.cleanSource ./.;
-  vendorSha256 = "1wihwj2rqv18vzn4kwnqwmpx03yiv2ib9yy317nwy6392zyczv8m";
+  vendorSha256 = "0knmyqls62i9y8h6h8p1h9m768ni58anfdiw5ljwc3n40l20hk2z";
 }

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,8 @@
+{ pkgs }:
+
+pkgs.buildGoModule {
+  pname = "go-nix";
+  version = "latest";
+  src = pkgs.lib.cleanSource ./.;
+  vendorSha256 = "1wihwj2rqv18vzn4kwnqwmpx03yiv2ib9yy317nwy6392zyczv8m";
+}

--- a/devshell.toml
+++ b/devshell.toml
@@ -1,0 +1,13 @@
+name = "go-nix"
+
+packages = [
+  "awscli",
+  "google-cloud-sdk",
+  "go",
+  "gopls",
+  "minio",
+  "minio-client",
+]
+
+[env]
+GO111MODULE = "on"

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,74 @@
+{
+  "nodes": {
+    "devshell": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1598609194,
+        "narHash": "sha256-BQ8n5Z/ZXUOjPdScA7rWDNH0W64r3eDB8hQbsaatAzE=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "bc52fb4c4841310b3dcdaf8f1e2b3f9f6bfeeb00",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1598466101,
+        "narHash": "sha256-JPhv+Ay98KMWRVRFlLEK9+eLpvNjhTBGWdFKZsE97ck=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "a586a6b966d59f53f45a04f8891fbc017dc09dbe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1596041494,
+        "narHash": "sha256-ya3rCWKDbPWMVsh89/Z1mCJ9HFa5/DKdjcgcKkWB1xs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "500d695aac9ea67195812f309890a911fbc96bda",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1598617282,
+        "narHash": "sha256-YveJHe1PdsvyirT2txdWNzV2vgbhC8wmoyH4Unb5b2E=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4eb9188da609619800e36c445dac5a21c6108395",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devshell": "devshell",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs_2"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -12,25 +12,25 @@
     //
     (
       flake-utils.lib.eachDefaultSystem (system:
-        let
-          pkgs = import nixpkgs {
-            inherit system;
-			overlays = [
-			  devshell.overlay
-              self.overlay
-            ];
-          };
-        in
-        rec {
-          packages.go-nix = pkgs.go-nix.lib;
-		  defaultPackage = pkgs.go-nix.lib;
-		  apps.go-nix = flake-utils.lib.mkApp { drv = pkgs.go-nix.lib; };
-		  defaultApp = apps.go-nix.lib;
-		  devShell = pkgs.mkDevShell.fromTOML ./devshell.toml;
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [
+            devshell.overlay
+            self.overlay
+          ];
+        };
+      in
+      rec {
+        packages.go-nix = pkgs.go-nix.lib;
+        defaultPackage = pkgs.go-nix.lib;
+        apps.go-nix = flake-utils.lib.mkApp { drv = pkgs.go-nix.lib; };
+        defaultApp = apps.go-nix.lib;
+        devShell = pkgs.mkDevShell.fromTOML ./devshell.toml;
 
-          # Additional checks on top of the packages
-          checks = { };
-        }
+        # Additional checks on top of the packages
+        checks = { };
+      }
       )
     );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,36 @@
+{
+  description = "go-nix - Nix experiments written in go";
+
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+  inputs.devshell.url = "github:numtide/devshell";
+
+  outputs =
+    { self, nixpkgs, flake-utils, devshell }:
+    {
+      overlay = import ./overlay.nix { };
+    }
+    //
+    (
+      flake-utils.lib.eachDefaultSystem (system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+			overlays = [
+			  devshell.overlay
+              self.overlay
+            ];
+          };
+        in
+        rec {
+          packages.go-nix = pkgs.go-nix.lib;
+		  defaultPackage = pkgs.go-nix.lib;
+		  apps.go-nix = flake-utils.lib.mkApp { drv = pkgs.go-nix.lib; };
+		  defaultApp = apps.go-nix.lib;
+		  devShell = pkgs.mkDevShell.fromTOML ./devshell.toml;
+
+          # Additional checks on top of the packages
+          checks = { };
+        }
+      )
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   outputs =
     { self, nixpkgs, flake-utils, devshell }:
     {
-      overlay = import ./overlay.nix { };
+      overlay = import ./overlay.nix;
     }
     //
     (
@@ -21,15 +21,12 @@
           ];
         };
       in
-      rec {
-        packages.go-nix = pkgs.go-nix.lib;
-        defaultPackage = pkgs.go-nix.lib;
-        apps.go-nix = flake-utils.lib.mkApp { drv = pkgs.go-nix.lib; };
-        defaultApp = apps.go-nix.lib;
+      {
+        packages = pkgs.go-nix;
         devShell = pkgs.mkDevShell.fromTOML ./devshell.toml;
-
-        # Additional checks on top of the packages
-        checks = { };
+        # devShell = pkgs.mkShell {
+        #   buildInputs = [ pkgs.go ];
+        # };
       }
       )
     );

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,7 +1,7 @@
 final: prev:
 {
   go-nix = {
-	lib = prev.callPackage ./. { pkgs = final; };
+    lib = prev.callPackage ./. { pkgs = final; };
     tests = prev.callPackage ./tests { pkgs = final; };
   };
 }

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,7 +1,4 @@
 final: prev:
 {
-  go-nix = {
-    lib = prev.callPackage ./. { pkgs = final; };
-    tests = prev.callPackage ./tests { pkgs = final; };
-  };
+  go-nix = prev.callPackage ./. { pkgs = prev; };
 }

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,0 +1,7 @@
+final: prev:
+{
+  go-nix = {
+	lib = prev.callPackage ./. { pkgs = final; };
+    tests = prev.callPackage ./tests { pkgs = final; };
+  };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,8 +1,0 @@
-with import <nixpkgs> {};
-mkShell {
-  buildInputs = [ go awscli minio minio-client];
-  shellHook = ''
-    unset GOPATH GOROOT
-    export GO111MODULE=on
-  '';
-}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -1,0 +1,8 @@
+{ pkgs }:
+
+pkgs.buildGoModule {
+  pname = "go-nix-test";
+  version = "latest";
+  src = pkgs.lib.cleanSource ./.;
+  vendorSha256 = "1wihwj2rqv18vzn4kwnqwmpx03yiv2ib9yy317nwy6392zyczv8n";
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -1,8 +1,0 @@
-{ pkgs }:
-
-pkgs.buildGoModule {
-  pname = "go-nix-test";
-  version = "latest";
-  src = pkgs.lib.cleanSource ./.;
-  vendorSha256 = "1wihwj2rqv18vzn4kwnqwmpx03yiv2ib9yy317nwy6392zyczv8n";
-}


### PR DESCRIPTION
This is still not working and got this error instead:
```
rizary@RizaryWin:~/numtide/go-nix$ nix develop --show-trace
error: --- TypeError -------------------------------------------------------- nix
at: (69:67) in file: /nix/store/n6k3sacy2qvygkpjy1d5g9bvnji943k3-source/lib/fixed-points.nix

    68|   #
    69|   extends = f: rattrs: self: let super = rattrs self; in super // f self super;
      |                                                                   ^
    70| 

attempt to call something which is not a function but a set
---------------------------------- show-trace -----------------------------------
trace: while evaluating 'extends'
at: (69:24) in file: /nix/store/n6k3sacy2qvygkpjy1d5g9bvnji943k3-source/lib/fixed-points.nix

    68|   #
    69|   extends = f: rattrs: self: let super = rattrs self; in super // f self super;
      |                        ^
    70| 

trace: from call site
at: (69:42) in file: /nix/store/n6k3sacy2qvygkpjy1d5g9bvnji943k3-source/lib/fixed-points.nix

    68|   #
    69|   extends = f: rattrs: self: let super = rattrs self; in super // f self super;
      |                                          ^
    70| 

trace: while evaluating 'extends'
at: (69:24) in file: /nix/store/n6k3sacy2qvygkpjy1d5g9bvnji943k3-source/lib/fixed-points.nix

    68|   #
    69|   extends = f: rattrs: self: let super = rattrs self; in super // f self super;
      |                        ^
    70| 

trace: from call site
at: (19:20) in file: /nix/store/n6k3sacy2qvygkpjy1d5g9bvnji943k3-source/lib/fixed-points.nix

    18|   # details.
    19|   fix = f: let x = f x; in x;
      |                    ^
    20| 

trace: while evaluating 'fix'
at: (19:9) in file: /nix/store/n6k3sacy2qvygkpjy1d5g9bvnji943k3-source/lib/fixed-points.nix

    18|   # details.
    19|   fix = f: let x = f x; in x;
      |         ^
    20| 

trace: from call site
at: (248:3) in file: /nix/store/n6k3sacy2qvygkpjy1d5g9bvnji943k3-source/pkgs/top-level/stage.nix

   247|   # Return the complete set of packages.
   248|   lib.fix toFix
      |   ^

trace: while evaluating anonymous lambdaction
at: (12:1) in file: /nix/store/n6k3sacy2qvygkpjy1d5g9bvnji943k3-source/pkgs/top-level/stage.nix

    11| 
    12| { ## Misc parameters kept the same for all stages
      | ^
    13|   ##

trace: from call site
at: (113:26) in file: /nix/store/n6k3sacy2qvygkpjy1d5g9bvnji943k3-source/pkgs/top-level/default.nix

   112|   # sets. Only apply arguments which no stdenv would want to override.
   113|   allPackages = newArgs: import ./stage.nix ({
      |                          ^
   114|     inherit lib nixpkgsFun;

trace: while evaluating 'allPackages'
at: (113:17) in file: /nix/store/n6k3sacy2qvygkpjy1d5g9bvnji943k3-source/pkgs/top-level/default.nix

   112|   # sets. Only apply arguments which no stdenv would want to override.
   113|   allPackages = newArgs: import ./stage.nix ({
      |                 ^
   114|     inherit lib nixpkgsFun;

trace: from call site
at: (101:12) in file: /nix/store/n6k3sacy2qvygkpjy1d5g9bvnji943k3-source/pkgs/stdenv/booter.nix

   100|       then args'
   101|       else allPackages ((builtins.removeAttrs args' ["selfBuild"]) // {
      |            ^
   102|         adjacentPackages = if args.selfBuild or true then null else rec {

trace: while evaluating 'folder'
at: (89:33) in file: /nix/store/n6k3sacy2qvygkpjy1d5g9bvnji943k3-source/pkgs/stdenv/booter.nix

    88|   # debugging purposes.
    89|   folder = nextStage: stageFun: prevStage: let
      |                                 ^
    90|     args = stageFun prevStage;

trace: from call site
at: (68:18) in file: /nix/store/n6k3sacy2qvygkpjy1d5g9bvnji943k3-source/pkgs/stdenv/booter.nix

    67|           # Note the cycle -- call-by-need ensures finite fold.
    68|           cur  = op pred (builtins.elemAt list n) succ;
      |                  ^
    69|           succ = go cur (n + 1);

trace: while evaluating 'go'
at: (63:18) in file: /nix/store/n6k3sacy2qvygkpjy1d5g9bvnji943k3-source/pkgs/stdenv/booter.nix

    62|       len = builtins.length list;
    63|       go = pred: n:
      |                  ^
    64|         if n == len

trace: from call site
at: (72:13) in file: /nix/store/n6k3sacy2qvygkpjy1d5g9bvnji943k3-source/pkgs/stdenv/booter.nix

    71|       lapp = lnul cur;
    72|       cur = go lapp 0;
      |             ^
    73|     in cur;

trace: while evaluating 'dfold'
at: (60:27) in file: /nix/store/n6k3sacy2qvygkpjy1d5g9bvnji943k3-source/pkgs/stdenv/booter.nix

    59|   */
    60|   dfold = op: lnul: rnul: list:
      |                           ^
    61|     let

trace: from call site
at: (136:4) in file: /nix/store/n6k3sacy2qvygkpjy1d5g9bvnji943k3-source/pkgs/stdenv/booter.nix

   135| 
   136| in dfold folder postStage (_: {}) withAllowCustomOverrides
      |    ^

trace: while evaluating anonymous lambdaction
at: (42:1) in file: /nix/store/n6k3sacy2qvygkpjy1d5g9bvnji943k3-source/pkgs/stdenv/booter.nix

    41| # other words, this does a foldr not foldl.
    42| stageFuns: let
      | ^
    43| 

trace: from call site
at: (123:10) in file: /nix/store/n6k3sacy2qvygkpjy1d5g9bvnji943k3-source/pkgs/top-level/default.nix

   122| 
   123|   pkgs = boot stages;
      |          ^
   124| 

trace: while evaluating anonymous lambdaction
at: (20:1) in file: /nix/store/n6k3sacy2qvygkpjy1d5g9bvnji943k3-source/pkgs/top-level/default.nix

    19| 
    20| { # The system packages will be built on. See the manual for the
      | ^
    21|   # subtle division of labor between these two `*System`s and the three

trace: from call site
at: (84:1) in file: /nix/store/n6k3sacy2qvygkpjy1d5g9bvnji943k3-source/pkgs/top-level/impure.nix

    83| 
    84| import ./. (builtins.removeAttrs args [ "system" "platform" ] // {
      | ^
    85|   inherit config overlays crossSystem crossOverlays;

trace: while evaluating anonymous lambdaction
at: (15:1) in file: /nix/store/n6k3sacy2qvygkpjy1d5g9bvnji943k3-source/pkgs/top-level/impure.nix

    14| 
    15| { # We combine legacy `system` and `platform` into `localSystem`, if
      | ^
    16|   # `localSystem` was not passed. Strictly speaking, this is pure desugar, but

trace: from call site
at: (16:18) in file: /nix/store/3wbxkgarr5pack0kqyawh1gr6ayrhgsn-source/flake.nix

    15|         let
    16|           pkgs = import nixpkgs {
      |                  ^
    17|             inherit system;

trace: while evaluating the attribute 'devShell'
at: (29:5) in file: /nix/store/3wbxkgarr5pack0kqyawh1gr6ayrhgsn-source/flake.nix

    28|                   defaultApp = apps.go-nix.lib;
    29|                   devShell = pkgs.mkDevShell.fromTOML ./devshell.toml;
      |     ^
    30| 
```

And without verbose only showing: 

```
rizary@RizaryWin:~/numtide/go-nix$ nix develop --show-trace
warning: Git tree '/home/rizary/numtide/go-nix' is dirty
error: --- EvalError ------------------- nix
cached failure of attribute 'devShell.x86_64-linux'
```

I keep failing to understand and debugging such error.