### PR TITLE
nar/serialize.go: fix reader

### DIFF
--- a/src/nar/hesitant_reader.go
+++ b/src/nar/hesitant_reader.go
@@ -1,0 +1,24 @@
+package nar
+
+import (
+	"io"
+)
+
+// hesitantReader implements an io.Reader
+type hesitantReader struct {
+	data [][]byte
+}
+
+// Read returns the topmost []byte in data, or io.EOF if empty
+func (r *hesitantReader) Read(p []byte) (n int, err error) {
+	if len(r.data) == 0 {
+		return 0, io.EOF
+	}
+	copy(p, r.data[0])
+	len_read := len(r.data[0])
+
+	// pop first element in r.data
+	r.data = r.data[1:]
+
+	return len_read, nil
+}

--- a/src/nar/serialize.go
+++ b/src/nar/serialize.go
@@ -63,15 +63,9 @@ const maxInt64 = 1<<63 - 1
 func readLongLong(r io.Reader) (int64, error) {
 	var num uint64
 	bs := make([]byte, 8, 8)
-	n, err := r.Read(bs)
-	if err != nil {
+	if _, err := io.ReadFull(r, bs); err != nil {
 		return 0, err
 	}
-	// FIXME: I think that io.Reader guarantees that
-	if n != 8 {
-		return 0, fmt.Errorf("expected to read 8 bytes, not %d", n)
-	}
-
 	num =
 		uint64(bs[0]) |
 			uint64(bs[1])<<8 |
@@ -86,7 +80,7 @@ func readLongLong(r io.Reader) (int64, error) {
 		return 0, fmt.Errorf("number is too big: %d > %d", num, maxInt64)
 	}
 
-	return int64(num), err
+	return int64(num), nil
 }
 
 func expectString(r io.Reader, expected string) error {

--- a/src/nar/serialize.go
+++ b/src/nar/serialize.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"math"
 )
 
 func readString(r io.Reader) (string, error) {
@@ -59,8 +60,6 @@ func readPadding(r io.Reader, l int64) error {
 	return nil
 }
 
-const maxInt64 = 1<<63 - 1
-
 func readLongLong(r io.Reader) (int64, error) {
 	bs := make([]byte, 8, 8)
 	if _, err := io.ReadFull(r, bs); err != nil {
@@ -70,8 +69,8 @@ func readLongLong(r io.Reader) (int64, error) {
 	// this is uint64, little endian
 	// we use int64 later, so error out if it's larger than what we're able to represent.
 	num := binary.LittleEndian.Uint64(bs)
-	if num > maxInt64 {
-		return 0, fmt.Errorf("number is too big: %d > %d", num, maxInt64)
+	if num > math.MaxInt64 {
+		return 0, fmt.Errorf("number is too big: %d > %d", num, math.MaxInt64)
 	}
 
 	return int64(num), nil

--- a/src/nar/serialize.go
+++ b/src/nar/serialize.go
@@ -1,6 +1,7 @@
 package nar
 
 import (
+	"encoding/binary"
 	"fmt"
 	"io"
 )
@@ -61,21 +62,14 @@ func readPadding(r io.Reader, l int64) error {
 const maxInt64 = 1<<63 - 1
 
 func readLongLong(r io.Reader) (int64, error) {
-	var num uint64
 	bs := make([]byte, 8, 8)
 	if _, err := io.ReadFull(r, bs); err != nil {
 		return 0, err
 	}
-	num =
-		uint64(bs[0]) |
-			uint64(bs[1])<<8 |
-			uint64(bs[2])<<16 |
-			uint64(bs[3])<<24 |
-			uint64(bs[4])<<32 |
-			uint64(bs[5])<<40 |
-			uint64(bs[6])<<48 |
-			uint64(bs[7])<<56
 
+	// this is uint64, little endian
+	// we use int64 later, so error out if it's larger than what we're able to represent.
+	num := binary.LittleEndian.Uint64(bs)
 	if num > maxInt64 {
 		return 0, fmt.Errorf("number is too big: %d > %d", num, maxInt64)
 	}

--- a/src/nar/serialize_test.go
+++ b/src/nar/serialize_test.go
@@ -15,5 +15,18 @@ func TestReadLongLong(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, num, int64(13))
+}
 
+// TestReadLongLongPartial constructs a reader not returning the full
+// string on the first Read() call
+func TestReadLongLongPartial(t *testing.T) {
+	r := &hesitantReader{data: [][]byte{
+		{13},
+		{},
+		{0, 0, 0, 0, 0, 0, 0},
+	}}
+
+	num, err := readLongLong(r)
+	assert.NoError(t, err)
+	assert.Equal(t, num, int64(13))
 }


### PR DESCRIPTION
There's no guarantees on how many bytes the Read() method of an io.Reader will write.
We can't assume it to block until all bytes requested are there - it can
return before (especially if it's still receiving on the other side).

This adds a "hesitantReader", which behaves like this, a failing unit test, then switches serialize.go over to use io.ReadFull (which behaves like we want it to).

After all that is done, we switch over to encoding/binary instead of bitshifting manually to produce the (u)int64.