### PR TITLE
nar: refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,5 @@ This repository holds a bunch of experiments written in Go.
 * nar - a Nix ARchive (NAR) file parser that mimics archive/tar from the
   stdlib
 * nar/ls - a parser for .ls files (providing an index for .nar files)
-* libstore - a narinfo parser
+* nar/narinfo - a parser for .narinfo files
+* libstore - some store implementations

--- a/README.md
+++ b/README.md
@@ -6,4 +6,5 @@ This repository holds a bunch of experiments written in Go.
 
 * nar - a Nix ARchive (NAR) file parser that mimics archive/tar from the
   stdlib
+* nar/ls - a parser for .ls files (providing an index for .nar files)
 * libstore - a narinfo parser

--- a/nar/doc.go
+++ b/nar/doc.go
@@ -1,3 +1,8 @@
-// Package nar implement functions to deal with the Nix Archive format. This
-// is the format that is being used to pack and distribute Nix build results.
+// Package tar implements access to .nar files.
+//
+// Nix Archive (nar) is a file format for storing a directory or a single file
+// in a binary reproducible format. This is the format that is being used to
+// pack and distribute Nix build results. It doesn't store any timestamps or
+// similar fields available in conventional filesystems. .nar files can be read
+// and written in a streaming manner.
 package nar

--- a/nar/ls/doc.go
+++ b/nar/ls/doc.go
@@ -1,0 +1,7 @@
+// Package ls implements a parser for the .ls file format, which provides an
+// index into .nar files.
+
+// It is provided on cache.nixos.org, and more generally, written when
+// write-nar-listing=1 is passed while copying build results into a binary
+// cache.
+package ls

--- a/nar/ls/list.go
+++ b/nar/ls/list.go
@@ -1,9 +1,11 @@
-package nar
+package ls
 
 import (
 	"encoding/json"
 	"fmt"
 	"io"
+
+	"github.com/numtide/go-nix/nar"
 )
 
 // LSRoot represents the .ls file root entry
@@ -14,7 +16,7 @@ type LSRoot struct {
 
 // LSEntry represents one of the entries in a .ls file
 type LSEntry struct {
-	Type       EntryType          `json:"type"`
+	Type       nar.EntryType      `json:"type"`
 	Entries    map[string]LSEntry `json:"entries"`
 	Size       int64              `json:"size"`
 	Target     string             `json:"target"`
@@ -22,7 +24,8 @@ type LSEntry struct {
 	NAROffset  int64              `json:"narOffset"`
 }
 
-// ParseLS parses the NAR .ls file format
+// ParseLS parses the NAR .ls file format.
+// It returns a tree-like structure for all the entries.
 func ParseLS(r io.Reader) (*LSRoot, error) {
 	root := LSRoot{}
 

--- a/nar/ls/list_test.go
+++ b/nar/ls/list_test.go
@@ -1,4 +1,4 @@
-package nar_test
+package ls
 
 import (
 	"strings"
@@ -32,18 +32,18 @@ const fixture = `
 
 func TestLS(t *testing.T) {
 	r := strings.NewReader(fixture)
-	root, err := nar.ParseLS(r)
+	root, err := ParseLS(r)
 	assert.NoError(t, err)
 
-	expected_root := &nar.LSRoot{
+	expected_root := &LSRoot{
 		Version: 1,
-		Root: nar.LSEntry{
+		Root: LSEntry{
 			Type: nar.TypeDirectory,
-			Entries: map[string]nar.LSEntry{
-				"bin": nar.LSEntry{
+			Entries: map[string]LSEntry{
+				"bin": LSEntry{
 					Type: nar.TypeDirectory,
-					Entries: map[string]nar.LSEntry{
-						"curl": nar.LSEntry{
+					Entries: map[string]LSEntry{
+						"curl": LSEntry{
 							Type:       nar.TypeRegular,
 							Size:       182520,
 							Executable: true,

--- a/nar/narinfo/parser.go
+++ b/nar/narinfo/parser.go
@@ -1,0 +1,94 @@
+package narinfo
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+)
+
+// Parse reads a .narinfo file content
+// and returns a NarInfo struct with the parsed data
+//
+// TODO: parse the FileHash and NarHash to make sure they are valid
+// TODO: validate that the StorePath is valid
+// TODO: validate the references to be valid store paths after being appended
+// to store.storeDir
+// TODO: validate the same for the deriver
+func Parse(r io.Reader) (*NarInfo, error) {
+	narInfo := &NarInfo{}
+	scanner := bufio.NewScanner(r)
+
+	for scanner.Scan() {
+		var err error
+
+		line := scanner.Text()
+
+		// skip empty lines (like, an empty line at EOF)
+		if line == "" {
+			continue
+		}
+		parts := strings.Split(line, ": ")
+
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("Unable to split line %v", line)
+		}
+
+		k := parts[0]
+		v := parts[1]
+
+		switch k {
+		case "StorePath":
+			narInfo.StorePath = v
+		case "URL":
+			narInfo.URL = v
+		case "Compression":
+			narInfo.Compression = v
+		case "FileHash":
+			narInfo.FileHash = v
+		case "FileSize":
+			narInfo.FileSize, err = strconv.Atoi(v)
+			if err != nil {
+				return nil, err
+			}
+		case "NarHash":
+			narInfo.NarHash = v
+		case "NarSize":
+			narInfo.NarSize, err = strconv.Atoi(v)
+			if err != nil {
+				return nil, err
+			}
+		case "References":
+			if v == "" {
+				continue
+			}
+			narInfo.References = append(narInfo.References, strings.Split(v, " ")...)
+		case "Deriver":
+			narInfo.Deriver = v
+		case "System":
+			narInfo.System = v
+		case "Sig":
+			narInfo.Signatures = append(narInfo.Signatures, v)
+		case "CA":
+			narInfo.CA = v
+		default:
+			return nil, fmt.Errorf("unknown key %v", k)
+		}
+
+		if err != nil {
+			return nil, fmt.Errorf("Unable to parse line %v", line)
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	// An empty/non-existrent compression field is considered to mean bzip2
+	if narInfo.Compression == "" {
+		narInfo.Compression = "bzip2"
+	}
+
+	return narInfo, nil
+}

--- a/nar/narinfo/test.go
+++ b/nar/narinfo/test.go
@@ -1,10 +1,9 @@
-package libstore_test
+package narinfo
 
 import (
 	"strings"
 	"testing"
 
-	"github.com/numtide/go-nix/libstore"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -25,12 +24,12 @@ Sig: hydra.other.net-1:JXQ3Z/PXf0EZSFkFioa4FbyYpbbTbHlFBtZf4VqU0tuMTWzhMD7p9Q7ac
 func TestNarInfoParser(t *testing.T) {
 	r := strings.NewReader(narinfoSample)
 
-	n, err := libstore.ParseNarInfo(r)
+	n, err := Parse(r)
 
 	assert.NoError(t, err)
 
 	// Test the parsing happy path
-	assert.Equal(t, &libstore.NarInfo{
+	assert.Equal(t, &NarInfo{
 		StorePath:   "/nix/store/00bgd045z0d4icpbc2yyz4gx48ak44la-net-tools-1.60_p20170221182432",
 		URL:         "nar/1094wph9z4nwlgvsd53abfz8i117ykiv5dwnq9nnhz846s7xqd7d.nar.xz",
 		Compression: "xz",

--- a/nar/narinfo/types.go
+++ b/nar/narinfo/types.go
@@ -1,15 +1,11 @@
-package libstore
+package narinfo
 
 import (
-	"bufio"
 	"bytes"
 	"fmt"
-	"io"
-	"strconv"
-	"strings"
 )
 
-// NarInfo represent the nar-info format
+// NarInfo represents a parsed .narinfo file
 type NarInfo struct {
 	StorePath string // The full nix store path (/nix/store/…-name-version)
 
@@ -40,91 +36,6 @@ type NarInfo struct {
 
 	// TODO: Figure out the meaning of this
 	CA string
-}
-
-// ParseNarInfo reads a .narinfo file content
-// and returns a NarInfo struct with the parsed data
-//
-// TODO: parse the FileHash and NarHash to make sure they are valid
-// TODO: validate that the StorePath is valid
-// TODO: validate the references to be valid store paths after being appended
-// to store.storeDir
-// TODO: validate the same for the deriver
-func ParseNarInfo(r io.Reader) (*NarInfo, error) {
-	narInfo := &NarInfo{}
-	scanner := bufio.NewScanner(r)
-
-	for scanner.Scan() {
-		var err error
-
-		line := scanner.Text()
-
-		// skip empty lines (like, an empty line at EOF)
-		if line == "" {
-			continue
-		}
-		parts := strings.Split(line, ": ")
-
-		if len(parts) != 2 {
-			return nil, fmt.Errorf("Unable to split line %v", line)
-		}
-
-		k := parts[0]
-		v := parts[1]
-
-		switch k {
-		case "StorePath":
-			narInfo.StorePath = v
-		case "URL":
-			narInfo.URL = v
-		case "Compression":
-			narInfo.Compression = v
-		case "FileHash":
-			narInfo.FileHash = v
-		case "FileSize":
-			narInfo.FileSize, err = strconv.Atoi(v)
-			if err != nil {
-				return nil, err
-			}
-		case "NarHash":
-			narInfo.NarHash = v
-		case "NarSize":
-			narInfo.NarSize, err = strconv.Atoi(v)
-			if err != nil {
-				return nil, err
-			}
-		case "References":
-			if v == "" {
-				continue
-			}
-			narInfo.References = append(narInfo.References, strings.Split(v, " ")...)
-		case "Deriver":
-			narInfo.Deriver = v
-		case "System":
-			narInfo.System = v
-		case "Sig":
-			narInfo.Signatures = append(narInfo.Signatures, v)
-		case "CA":
-			narInfo.CA = v
-		default:
-			return nil, fmt.Errorf("unknown key %v", k)
-		}
-
-		if err != nil {
-			return nil, fmt.Errorf("Unable to parse line %v", line)
-		}
-	}
-
-	if err := scanner.Err(); err != nil {
-		return nil, err
-	}
-
-	// An empty/non-existrent compression field is considered to mean bzip2
-	if narInfo.Compression == "" {
-		narInfo.Compression = "bzip2"
-	}
-
-	return narInfo, nil
 }
 
 func (n *NarInfo) String() string {


### PR DESCRIPTION
See individual commits for details.

This provides some more documentation, moves some things to more intuitive locations (`nar/list*` -> `nar/ls/`, `libstore/nar_info*` -> `nar/narinfo`), and simplifies the .narfile parser.