### PR TITLE
pkg/wire: add more tests

### DIFF
--- a/pkg/wire/bytes_reader.go
+++ b/pkg/wire/bytes_reader.go
@@ -1,0 +1,55 @@
+package wire
+
+import (
+	"io"
+)
+
+// BytesReader implements io.ReadCloser.
+var _ io.ReadCloser = &BytesReader{}
+
+// BytesReader implements reading from bytes fields.
+// It'll return a limited reader to the actual contents,
+// and will take care of skipping and seeking over the padding on Close.
+type BytesReader struct {
+	contentLength uint64    // the total length of the field
+	lr            io.Reader // a reader limited to the actual contents of the field
+	r             io.Reader // the underlying real reader, used when seeking over the padding.
+}
+
+// NewBytesReader constructs a Reader of a bytes packet.
+// Closing the reader will skip over any padding.
+func NewBytesReader(r io.Reader, contentLength uint64) *BytesReader {
+	return &BytesReader{
+		contentLength: contentLength,
+		lr:            io.LimitReader(r, int64(contentLength)),
+		r:             r,
+	}
+}
+
+// Read will read into b until all bytes from the field have been read
+// Keep in mind there might be some padding at the end still,
+// which can be seek'ed over by closing the reader.
+func (br *BytesReader) Read(b []byte) (int, error) {
+	n, err := br.lr.Read(b)
+
+	return n, err
+}
+
+// Close will skip to the end and consume any remaining padding.
+func (br *BytesReader) Close() error {
+	// seek to the end of the limited reader
+	for {
+		buf := make([]byte, 1024)
+
+		_, err := br.lr.Read(buf)
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+
+			return err
+		}
+	}
+	// skip over padding
+	return readPadding(br.r, br.contentLength)
+}

--- a/pkg/wire/read_test.go
+++ b/pkg/wire/read_test.go
@@ -118,3 +118,19 @@ func TestReadBytes(t *testing.T) {
 		assert.Equal(t, buf, []byte{42, 23, 42, 23, 42, 23, 42, 23})
 	}
 }
+
+func TestReadString(t *testing.T) {
+	payloadFoo := []byte{
+		3, 0, 0, 0, 0, 0, 0, 0, // length field - 3 bytes
+		0x46, 0x6F, 0x6F, 0, 0, 0, 0, 0, // contents, Foo, then 5 bytes padding
+	}
+
+	s, err := wire.ReadString(bytes.NewReader(payloadFoo), 1024)
+	if assert.NoError(t, err) {
+		assert.Equal(t, s, "Foo")
+	}
+
+	// exceeding max should error
+	_, err = wire.ReadString(bytes.NewReader(payloadFoo), 2)
+	assert.Error(t, err)
+}

--- a/pkg/wire/read_test.go
+++ b/pkg/wire/read_test.go
@@ -53,3 +53,23 @@ func TestReadUint64Slow(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, num, uint64(13))
 }
+
+// TestReadBool tests reading boolean values works.
+func TestReadBool(t *testing.T) {
+	rdBytesFalse := bytes.NewReader([]byte{0, 0, 0, 0, 0, 0, 0, 0})
+	rdBytesTrue := bytes.NewReader([]byte{1, 0, 0, 0, 0, 0, 0, 0})
+	rdBytesInvalidBool := bytes.NewReader([]byte{2, 0, 0, 0, 0, 0, 0, 0})
+
+	v, err := wire.ReadBool(rdBytesFalse)
+	if assert.NoError(t, err) {
+		assert.Equal(t, v, false)
+	}
+
+	v, err = wire.ReadBool(rdBytesTrue)
+	if assert.NoError(t, err) {
+		assert.Equal(t, v, true)
+	}
+
+	_, err = wire.ReadBool(rdBytesInvalidBool)
+	assert.Error(t, err)
+}

--- a/pkg/wire/read_test.go
+++ b/pkg/wire/read_test.go
@@ -1,10 +1,11 @@
-package wire
+package wire_test
 
 import (
 	"bytes"
 	"io"
 	"testing"
 
+	"github.com/numtide/go-nix/pkg/wire"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -33,7 +34,7 @@ func TestReadUint64(t *testing.T) {
 	bs := []byte{13, 0, 0, 0, 0, 0, 0, 0}
 	r := bytes.NewReader(bs)
 
-	num, err := ReadUint64(r)
+	num, err := wire.ReadUint64(r)
 
 	assert.NoError(t, err)
 	assert.Equal(t, num, uint64(13))
@@ -48,7 +49,7 @@ func TestReadUint64Slow(t *testing.T) {
 		{0, 0, 0, 0, 0, 0, 0},
 	}}
 
-	num, err := ReadUint64(r)
+	num, err := wire.ReadUint64(r)
 	assert.NoError(t, err)
 	assert.Equal(t, num, uint64(13))
 }


### PR DESCRIPTION
`pkg/wire` test additions and refactor spun out of https://github.com/numtide/go-nix/pull/25:

 - 3ed3531 feat(pkg/wire/read_test.go): add ReadString tests
 - aa2b6cd feat(pkg/wire/read_test.go): add ReadBytesFull test cases
 - 802d8b5 feat(pkg/wire/read_test.go): add bool test cases
 - 243c35e feat(pkg/wire): make ReadBytes return a io.ReadCloser, add ReadBytesFull function
 - d431594 fix(pkg/wire): rename tests to read_test.go